### PR TITLE
Add access no style

### DIFF
--- a/style.json
+++ b/style.json
@@ -3330,7 +3330,6 @@
       ],
       "paint": {
         "line-color": "rgba(222, 222, 222, 1)",
-        "line-opacity": 1,
         "line-width": {
           "base": 1.2,
           "stops": [
@@ -3348,9 +3347,10 @@
             ]
           ]
         },
+        "line-opacity": 0.5,
         "line-dasharray": [
           2,
-          1.5
+          0.5
         ]
       }
     },

--- a/style.json
+++ b/style.json
@@ -3323,9 +3323,17 @@
           "LineString"
         ],
         [
-          "==",
-          "access",
-          "no"
+          "any",
+          [
+            "==",
+            "access",
+            "no"
+          ],
+          [
+            "==",
+            "access",
+            "private"
+          ]
         ]
       ],
       "paint": {
@@ -3347,11 +3355,7 @@
             ]
           ]
         },
-        "line-opacity": 0.5,
-        "line-dasharray": [
-          2,
-          0.5
-        ]
+        "line-opacity": 0.5
       }
     },
     {

--- a/style.json
+++ b/style.json
@@ -3310,6 +3310,51 @@
       }
     },
     {
+      "id": "highway-minor-access-forbidden",
+      "type": "line",
+      "source": "geolonia",
+      "source-layer": "transportation",
+      "minzoom": 13,
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "LineString"
+        ],
+        [
+          "==",
+          "access",
+          "no"
+        ]
+      ],
+      "paint": {
+        "line-color": "rgba(222, 222, 222, 1)",
+        "line-opacity": 1,
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              13.5,
+              0
+            ],
+            [
+              14,
+              2.5
+            ],
+            [
+              20,
+              11.5
+            ]
+          ]
+        },
+        "line-dasharray": [
+          2,
+          1.5
+        ]
+      }
+    },
+    {
       "id": "highway-secondary-tertiary",
       "type": "line",
       "source": "geolonia",

--- a/style.json
+++ b/style.json
@@ -4850,7 +4850,7 @@
       "paint": {}
     },
     {
-      "id": "road-access-forbidden",
+      "id": "road_access_forbidden",
       "type": "line",
       "source": "geolonia",
       "source-layer": "transportation",

--- a/style.json
+++ b/style.json
@@ -3310,55 +3310,6 @@
       }
     },
     {
-      "id": "highway-minor-access-forbidden",
-      "type": "line",
-      "source": "geolonia",
-      "source-layer": "transportation",
-      "minzoom": 13,
-      "filter": [
-        "all",
-        [
-          "==",
-          "$type",
-          "LineString"
-        ],
-        [
-          "any",
-          [
-            "==",
-            "access",
-            "no"
-          ],
-          [
-            "==",
-            "access",
-            "private"
-          ]
-        ]
-      ],
-      "paint": {
-        "line-color": "rgba(222, 222, 222, 1)",
-        "line-width": {
-          "base": 1.2,
-          "stops": [
-            [
-              13.5,
-              0
-            ],
-            [
-              14,
-              2.5
-            ],
-            [
-              20,
-              11.5
-            ]
-          ]
-        },
-        "line-opacity": 0.5
-      }
-    },
-    {
       "id": "highway-secondary-tertiary",
       "type": "line",
       "source": "geolonia",
@@ -4897,6 +4848,55 @@
         "icon-size": 1
       },
       "paint": {}
+    },
+    {
+      "id": "road-access-forbidden",
+      "type": "line",
+      "source": "geolonia",
+      "source-layer": "transportation",
+      "minzoom": 13,
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "LineString"
+        ],
+        [
+          "any",
+          [
+            "==",
+            "access",
+            "no"
+          ],
+          [
+            "==",
+            "access",
+            "private"
+          ]
+        ]
+      ],
+      "paint": {
+        "line-color": "rgba(222, 222, 222, 1)",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              13.5,
+              0
+            ],
+            [
+              14,
+              2.5
+            ],
+            [
+              20,
+              11.5
+            ]
+          ]
+        },
+        "line-opacity": 0.5
+      }
     },
     {
       "id": "airport-label-major",


### PR DESCRIPTION
Related to https://github.com/geolonia/tilemaker-geolonia/issues/11

`access=="private" or access=="no"`  のスタイルを追加。`rgba(222, 222, 222, 1)` で透明度 0.5 にしました。

![スクリーンショット 2021-07-09 14 56 58](https://user-images.githubusercontent.com/8760841/125030417-12e3d680-e0c6-11eb-8964-4b5431149a7d.png)

## プレビューURL

https://deploy-preview-36--style-basic.netlify.app/#17.87/35.682231/139.750598

## OpenStreetMap

https://www.openstreetmap.org/edit#map=17/35.68177/139.75127

