### PR TITLE
国立公園を除外

### DIFF
--- a/style.json
+++ b/style.json
@@ -1605,9 +1605,17 @@
       "source": "geolonia",
       "source-layer": "park",
       "filter": [
-        "==",
-        "$type",
-        "Polygon"
+        "all",
+        [
+          "==",
+          "$type",
+          "Polygon"
+        ],
+        [
+          "!=",
+          "class",
+          "national_park"
+        ]
       ],
       "layout": {
         "visibility": "visible"


### PR DESCRIPTION
国立公園が表示されていたので非表示にしました。

- 霧島錦江湾国立公園
https://geolonia.github.io/preview/?style=geolonia/basic#11.92/31.6134/130.72498

国立公園の制度について共有しておくと、こんな感じのものです:
- 都市公園とは違うもの。柵で囲われているわけではなく、法規制がある景観保全のための区域と考えて良い
- 海も指定されている
- 国立公園以外にも国定公園と都道府県立自然公園がある

なので、geolonia/basic ではポリゴンとして表示する必要は無いと思います。

なぜ霧島錦江湾国立公園だけ表示されているのかですが、おそらくたまたま霧島錦江湾国立公園のポリゴンが混ざっていたのだと思います。  国立公園は全国分チェックしたので、他には紛れ込んでいないと思います。
国定公園や都道府県立自然公園はそもそもポリゴンの入手が困難なのでおそらく紛れ込んでいることは無いと思います。  以前知床国立公園のポリゴンも表示されていましたが、それってどうなったんでしたっけ..? 