### PR TITLE
海上国道や未成道に対する国道番号標識を非表示に

### DIFF
--- a/style.json
+++ b/style.json
@@ -4816,6 +4816,11 @@
           "!=",
           "disputed",
           "japan_northern_territories"
+        ],
+        [
+          "!=",
+          "class",
+          "planned"
         ]
       ],
       "layout": {


### PR DESCRIPTION
これらは `class=planned` としてプロパティが振られているため、それをフィルターするようにしました。
close #39