### PR TITLE
ズームレベル5未満でも森林を表示したい

### DIFF
--- a/style.json
+++ b/style.json
@@ -489,7 +489,7 @@
       "type": "fill",
       "source": "oceanus",
       "source-layer": "oc-forest",
-      "minzoom": 5,
+      "minzoom": 0,
       "maxzoom": 8,
       "layout": {
         "visibility": "visible"


### PR DESCRIPTION
oc-forest の minzoom:5 に設定されたいので、z5未満では白地図になっていたので森を表示するように修正しました。

Before
<img width="772" alt="スクリーンショット 2021-07-30 14 39 25" src="https://user-images.githubusercontent.com/8760841/127606170-bf3aa83d-a848-4690-aa26-7af7528b44e5.png">

After
![スクリーンショット 2021-07-30 14 41 55](https://user-images.githubusercontent.com/8760841/127606267-a1c1ddb7-276a-43be-8c5a-9fa2fea2c202.png)

