### PR TITLE
未成道の番号標識を非表示にするスタイルを取り除く

### DIFF
--- a/style.json
+++ b/style.json
@@ -4819,11 +4819,6 @@
           "!=",
           "disputed",
           "japan_northern_territories"
-        ],
-        [
-          "!=",
-          "class",
-          "planned"
         ]
       ],
       "layout": {


### PR DESCRIPTION
タイル側の対応でもはや不要になったため。
close #42