### PR TITLE
市区町村のズームレベルとテキストサイズを、人口別に調整。

### DIFF
--- a/style.json
+++ b/style.json
@@ -4402,12 +4402,12 @@
     {
       "id": "building-3d",
       "type": "fill-extrusion",
-      "source": "geolonia",
-      "source-layer": "building",
-      "minzoom": 15,
       "metadata": {
         "visible-on-3d": true
       },
+      "source": "geolonia",
+      "source-layer": "building",
+      "minzoom": 15,
       "layout": {
         "visibility": "none"
       },
@@ -4989,6 +4989,7 @@
       "type": "symbol",
       "source": "geolonia",
       "source-layer": "place",
+      "minzoom": 9,
       "filter": [
         "all",
         [
@@ -5034,6 +5035,7 @@
       "type": "symbol",
       "source": "geolonia",
       "source-layer": "place",
+      "minzoom": 8,
       "filter": [
         "all",
         [
@@ -5051,7 +5053,7 @@
         "text-font": [
           "Noto Sans Regular"
         ],
-        "text-size": 14,
+        "text-size": 12,
         "text-field": "{name}",
         "text-max-width": 8,
         "visibility": "visible"
@@ -5120,22 +5122,47 @@
       }
     },
     {
-      "id": "place-city",
+      "id": "place-city-rank6-later",
       "type": "symbol",
       "source": "geolonia",
       "source-layer": "place",
-      "minzoom": 8,
+      "minzoom": 10,
       "filter": [
         "all",
-        [
-          "!=",
-          "capital",
-          2
-        ],
         [
           "==",
           "class",
           "city"
+        ],
+        [
+          "<=",
+          "rank",
+          6
+        ],
+        [
+          "!=",
+          "disputed",
+          "japan_northern_territories"
+        ]
+      ]
+    },
+    {
+      "id": "place-city-rank5",
+      "type": "symbol",
+      "source": "geolonia",
+      "source-layer": "place",
+      "minzoom": 10,
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "city"
+        ],
+        [
+          "==",
+          "rank",
+          5
         ],
         [
           "!=",
@@ -5148,6 +5175,123 @@
           "Noto Sans Regular"
         ],
         "text-size": 14,
+        "text-field": "{name}",
+        "text-max-width": 8,
+        "visibility": "visible"
+      },
+      "paint": {
+        "text-color": "rgba(102, 102, 102, 1)",
+        "text-halo-width": 1.2,
+        "text-halo-color": "rgba(255,255,255,0.8)"
+      }
+    },
+    {
+      "id": "place-city-rank4",
+      "type": "symbol",
+      "source": "geolonia",
+      "source-layer": "place",
+      "minzoom": 9,
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "city"
+        ],
+        [
+          "==",
+          "rank",
+          4
+        ],
+        [
+          "!=",
+          "disputed",
+          "japan_northern_territories"
+        ]
+      ],
+      "layout": {
+        "text-font": [
+          "Noto Sans Regular"
+        ],
+        "text-size": 14,
+        "text-field": "{name}",
+        "text-max-width": 8,
+        "visibility": "visible"
+      },
+      "paint": {
+        "text-color": "rgba(102, 102, 102, 1)",
+        "text-halo-width": 1.2,
+        "text-halo-color": "rgba(255,255,255,0.8)"
+      }
+    },
+    {
+      "id": "place-city-rank3",
+      "type": "symbol",
+      "source": "geolonia",
+      "source-layer": "place",
+      "minzoom": 8,
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "city"
+        ],
+        [
+          "==",
+          "rank",
+          3
+        ],
+        [
+          "!=",
+          "disputed",
+          "japan_northern_territories"
+        ]
+      ],
+      "layout": {
+        "text-font": [
+          "Noto Sans Regular"
+        ],
+        "text-size": 16,
+        "text-field": "{name}",
+        "text-max-width": 8,
+        "visibility": "visible"
+      },
+      "paint": {
+        "text-color": "rgba(102, 102, 102, 1)",
+        "text-halo-width": 1.2,
+        "text-halo-color": "rgba(255,255,255,0.8)"
+      }
+    },
+    {
+      "id": "place-city-rank2",
+      "type": "symbol",
+      "source": "geolonia",
+      "source-layer": "place",
+      "minzoom": 8,
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "city"
+        ],
+        [
+          "==",
+          "rank",
+          2
+        ],
+        [
+          "!=",
+          "disputed",
+          "japan_northern_territories"
+        ]
+      ],
+      "layout": {
+        "text-font": [
+          "Noto Sans Regular"
+        ],
+        "text-size": 18,
         "text-field": "{name}",
         "text-max-width": 8,
         "visibility": "visible"

--- a/style.json
+++ b/style.json
@@ -5122,7 +5122,7 @@
       }
     },
     {
-      "id": "place-city-rank6-later",
+      "id": "place-city-rank6-more",
       "type": "symbol",
       "source": "geolonia",
       "source-layer": "place",
@@ -5140,7 +5140,7 @@
           "city"
         ],
         [
-          "<=",
+          ">=",
           "rank",
           6
         ],

--- a/style.json
+++ b/style.json
@@ -5050,6 +5050,13 @@
         ]
       ],
       "layout": {
+        "icon-image": "circle-11",
+        "icon-size": 0.4,
+        "text-anchor": "top",
+        "text-offset": [
+          0,
+          0.2
+        ],
         "text-font": [
           "Noto Sans Regular"
         ],
@@ -5059,6 +5066,31 @@
         "visibility": "visible"
       },
       "paint": {
+        "icon-color": "#000000",
+        "icon-opacity": {
+          "stops": [
+            [
+              8,
+              1
+            ],
+            [
+              9,
+              1
+            ],
+            [
+              10,
+              1
+            ],
+            [
+              11,
+              1
+            ],
+            [
+              12,
+              0
+            ]
+          ]
+        },
         "text-color": "rgba(102, 102, 102, 1)",
         "text-halo-width": 1.2,
         "text-halo-color": "rgba(255,255,255,0.8)"

--- a/style.json
+++ b/style.json
@@ -5004,6 +5004,13 @@
         ]
       ],
       "layout": {
+        "icon-image": "circle-11",
+        "icon-size": 0.3,
+        "text-anchor": "top",
+        "text-offset": [
+          0,
+          0.2
+        ],
         "text-font": [
           "Noto Sans Regular"
         ],
@@ -5025,6 +5032,31 @@
         "visibility": "visible"
       },
       "paint": {
+        "icon-color": "#000000",
+        "icon-opacity": {
+          "stops": [
+            [
+              8,
+              1
+            ],
+            [
+              9,
+              1
+            ],
+            [
+              10,
+              1
+            ],
+            [
+              11,
+              1
+            ],
+            [
+              12,
+              0
+            ]
+          ]
+        },
         "text-color": "#333",
         "text-halo-width": 1.2,
         "text-halo-color": "rgba(255,255,255,0.8)"
@@ -5051,7 +5083,7 @@
       ],
       "layout": {
         "icon-image": "circle-11",
-        "icon-size": 0.4,
+        "icon-size": 0.3,
         "text-anchor": "top",
         "text-offset": [
           0,
@@ -5183,6 +5215,13 @@
         ]
       ],
       "layout": {
+        "icon-image": "circle-11",
+        "icon-size": 0.3,
+        "text-anchor": "top",
+        "text-offset": [
+          0,
+          0.2
+        ],
         "text-font": [
           "Noto Sans Regular"
         ],
@@ -5192,6 +5231,31 @@
         "visibility": "visible"
       },
       "paint": {
+        "icon-color": "#000000",
+        "icon-opacity": {
+          "stops": [
+            [
+              8,
+              1
+            ],
+            [
+              9,
+              1
+            ],
+            [
+              10,
+              1
+            ],
+            [
+              11,
+              1
+            ],
+            [
+              12,
+              0
+            ]
+          ]
+        },
         "text-color": "rgba(102, 102, 102, 1)",
         "text-halo-width": 1.2,
         "text-halo-color": "rgba(255,255,255,0.8)"
@@ -5227,6 +5291,13 @@
         ]
       ],
       "layout": {
+        "icon-image": "circle-11",
+        "icon-size": 0.3,
+        "text-anchor": "top",
+        "text-offset": [
+          0,
+          0.2
+        ],
         "text-font": [
           "Noto Sans Regular"
         ],
@@ -5236,6 +5307,31 @@
         "visibility": "visible"
       },
       "paint": {
+        "icon-color": "#000000",
+        "icon-opacity": {
+          "stops": [
+            [
+              8,
+              1
+            ],
+            [
+              9,
+              1
+            ],
+            [
+              10,
+              1
+            ],
+            [
+              11,
+              1
+            ],
+            [
+              12,
+              0
+            ]
+          ]
+        },
         "text-color": "rgba(102, 102, 102, 1)",
         "text-halo-width": 1.2,
         "text-halo-color": "rgba(255,255,255,0.8)"
@@ -5271,6 +5367,13 @@
         ]
       ],
       "layout": {
+        "icon-image": "circle-11",
+        "icon-size": 0.3,
+        "text-anchor": "top",
+        "text-offset": [
+          0,
+          0.2
+        ],
         "text-font": [
           "Noto Sans Regular"
         ],
@@ -5280,6 +5383,31 @@
         "visibility": "visible"
       },
       "paint": {
+        "icon-color": "#000000",
+        "icon-opacity": {
+          "stops": [
+            [
+              8,
+              1
+            ],
+            [
+              9,
+              1
+            ],
+            [
+              10,
+              1
+            ],
+            [
+              11,
+              1
+            ],
+            [
+              12,
+              0
+            ]
+          ]
+        },
         "text-color": "rgba(102, 102, 102, 1)",
         "text-halo-width": 1.2,
         "text-halo-color": "rgba(255,255,255,0.8)"
@@ -5315,6 +5443,13 @@
         ]
       ],
       "layout": {
+        "icon-image": "circle-11",
+        "icon-size": 0.3,
+        "text-anchor": "top",
+        "text-offset": [
+          0,
+          0.2
+        ],
         "text-font": [
           "Noto Sans Regular"
         ],
@@ -5324,6 +5459,31 @@
         "visibility": "visible"
       },
       "paint": {
+        "icon-color": "#000000",
+        "icon-opacity": {
+          "stops": [
+            [
+              8,
+              1
+            ],
+            [
+              9,
+              1
+            ],
+            [
+              10,
+              1
+            ],
+            [
+              11,
+              1
+            ],
+            [
+              12,
+              0
+            ]
+          ]
+        },
         "text-color": "rgba(102, 102, 102, 1)",
         "text-halo-width": 1.2,
         "text-halo-color": "rgba(255,255,255,0.8)"
@@ -5359,6 +5519,13 @@
         ]
       ],
       "layout": {
+        "icon-image": "circle-11",
+        "icon-size": 0.3,
+        "text-anchor": "top",
+        "text-offset": [
+          0,
+          0.2
+        ],
         "text-font": [
           "Noto Sans Regular"
         ],
@@ -5368,6 +5535,31 @@
         "visibility": "visible"
       },
       "paint": {
+        "icon-color": "#000000",
+        "icon-opacity": {
+          "stops": [
+            [
+              8,
+              1
+            ],
+            [
+              9,
+              1
+            ],
+            [
+              10,
+              1
+            ],
+            [
+              11,
+              1
+            ],
+            [
+              12,
+              0
+            ]
+          ]
+        },
         "text-color": "rgba(102, 102, 102, 1)",
         "text-halo-width": 1.2,
         "text-halo-color": "rgba(255,255,255,0.8)"
@@ -5403,6 +5595,13 @@
         ]
       ],
       "layout": {
+        "icon-image": "circle-11",
+        "icon-size": 0.3,
+        "text-anchor": "top",
+        "text-offset": [
+          0,
+          0.2
+        ],
         "text-font": [
           "Noto Sans Regular"
         ],
@@ -5412,6 +5611,31 @@
         "visibility": "visible"
       },
       "paint": {
+        "icon-color": "#000000",
+        "icon-opacity": {
+          "stops": [
+            [
+              8,
+              1
+            ],
+            [
+              9,
+              1
+            ],
+            [
+              10,
+              1
+            ],
+            [
+              11,
+              1
+            ],
+            [
+              12,
+              0
+            ]
+          ]
+        },
         "text-color": "rgba(102, 102, 102, 1)",
         "text-halo-width": 1.2,
         "text-halo-color": "rgba(255,255,255,0.8)"
@@ -5447,6 +5671,13 @@
         ]
       ],
       "layout": {
+        "icon-image": "circle-11",
+        "icon-size": 0.3,
+        "text-anchor": "top",
+        "text-offset": [
+          0,
+          0.2
+        ],
         "text-font": [
           "Noto Sans Regular"
         ],
@@ -5456,6 +5687,31 @@
         "visibility": "visible"
       },
       "paint": {
+        "icon-color": "#000000",
+        "icon-opacity": {
+          "stops": [
+            [
+              8,
+              1
+            ],
+            [
+              9,
+              1
+            ],
+            [
+              10,
+              1
+            ],
+            [
+              11,
+              1
+            ],
+            [
+              12,
+              0
+            ]
+          ]
+        },
         "text-color": "rgba(102, 102, 102, 1)",
         "text-halo-width": 1.2,
         "text-halo-color": "rgba(255,255,255,0.8)"
@@ -5491,6 +5747,13 @@
         ]
       ],
       "layout": {
+        "icon-image": "circle-11",
+        "icon-size": 0.4,
+        "text-anchor": "top",
+        "text-offset": [
+          0,
+          0.2
+        ],
         "text-font": [
           "Noto Sans Regular"
         ],
@@ -5500,6 +5763,31 @@
         "visibility": "visible"
       },
       "paint": {
+        "icon-color": "#000000",
+        "icon-opacity": {
+          "stops": [
+            [
+              8,
+              1
+            ],
+            [
+              9,
+              1
+            ],
+            [
+              10,
+              1
+            ],
+            [
+              11,
+              1
+            ],
+            [
+              12,
+              0
+            ]
+          ]
+        },
         "text-color": "rgba(102, 102, 102, 1)",
         "text-halo-width": 1.2,
         "text-halo-color": "rgba(255,255,255,0.8)"
@@ -5535,6 +5823,13 @@
         ]
       ],
       "layout": {
+        "icon-image": "circle-11",
+        "icon-size": 0.5,
+        "text-anchor": "top",
+        "text-offset": [
+          0,
+          0.2
+        ],
         "text-font": [
           "Noto Sans Regular"
         ],
@@ -5544,6 +5839,31 @@
         "visibility": "visible"
       },
       "paint": {
+        "icon-color": "#000000",
+        "icon-opacity": {
+          "stops": [
+            [
+              8,
+              1
+            ],
+            [
+              9,
+              1
+            ],
+            [
+              10,
+              1
+            ],
+            [
+              11,
+              1
+            ],
+            [
+              12,
+              0
+            ]
+          ]
+        },
         "text-color": "rgba(102, 102, 102, 1)",
         "text-halo-width": 1.2,
         "text-halo-color": "rgba(255,255,255,0.8)"

--- a/style.json
+++ b/style.json
@@ -4985,6 +4985,84 @@
       }
     },
     {
+      "id": "place-village",
+      "type": "symbol",
+      "source": "geolonia",
+      "source-layer": "place",
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "village"
+        ],
+        [
+          "!=",
+          "disputed",
+          "japan_northern_territories"
+        ]
+      ],
+      "layout": {
+        "text-font": [
+          "Noto Sans Regular"
+        ],
+        "text-size": {
+          "base": 1.2,
+          "stops": [
+            [
+              10,
+              12
+            ],
+            [
+              15,
+              22
+            ]
+          ]
+        },
+        "text-field": "{name}",
+        "text-max-width": 8,
+        "visibility": "visible"
+      },
+      "paint": {
+        "text-color": "#333",
+        "text-halo-width": 1.2,
+        "text-halo-color": "rgba(255,255,255,0.8)"
+      }
+    },
+    {
+      "id": "place-town",
+      "type": "symbol",
+      "source": "geolonia",
+      "source-layer": "place",
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "town"
+        ],
+        [
+          "!=",
+          "disputed",
+          "japan_northern_territories"
+        ]
+      ],
+      "layout": {
+        "text-font": [
+          "Noto Sans Regular"
+        ],
+        "text-size": 14,
+        "text-field": "{name}",
+        "text-max-width": 8,
+        "visibility": "visible"
+      },
+      "paint": {
+        "text-color": "rgba(102, 102, 102, 1)",
+        "text-halo-width": 1.2,
+        "text-halo-color": "rgba(255,255,255,0.8)"
+      }
+    },
+    {
       "id": "place-island-name",
       "type": "symbol",
       "source": "geolonia",
@@ -5042,71 +5120,7 @@
       }
     },
     {
-      "id": "place-city-rank6-later",
-      "type": "symbol",
-      "source": "geolonia",
-      "source-layer": "place",
-      "minzoom": 9,
-      "filter": [
-        "all",
-        [
-          "==",
-          "class",
-          "city"
-        ],
-        [
-          "==",
-          "rank",
-          5
-        ],
-        [
-          "!=",
-          "disputed",
-          "japan_northern_territories"
-        ]
-      ]
-    },
-    {
-      "id": "place-city-rank5",
-      "type": "symbol",
-      "source": "geolonia",
-      "source-layer": "place",
-      "minzoom": 9,
-      "filter": [
-        "all",
-        [
-          "==",
-          "class",
-          "city"
-        ],
-        [
-          "==",
-          "rank",
-          5
-        ],
-        [
-          "!=",
-          "disputed",
-          "japan_northern_territories"
-        ]
-      ],
-      "layout": {
-        "text-font": [
-          "Noto Sans Regular"
-        ],
-        "text-size": 14,
-        "text-field": "{name}",
-        "text-max-width": 8,
-        "visibility": "visible"
-      },
-      "paint": {
-        "text-color": "rgba(102, 102, 102, 1)",
-        "text-halo-width": 1.2,
-        "text-halo-color": "rgba(255,255,255,0.8)"
-      }
-    },
-    {
-      "id": "place-city-rank4",
+      "id": "place-city",
       "type": "symbol",
       "source": "geolonia",
       "source-layer": "place",
@@ -5114,92 +5128,14 @@
       "filter": [
         "all",
         [
-          "==",
-          "class",
-          "city"
-        ],
-        [
-          "==",
-          "rank",
-          4
-        ],
-        [
           "!=",
-          "disputed",
-          "japan_northern_territories"
-        ]
-      ],
-      "layout": {
-        "text-font": [
-          "Noto Sans Regular"
-        ],
-        "text-size": 14,
-        "text-field": "{name}",
-        "text-max-width": 8,
-        "visibility": "visible"
-      },
-      "paint": {
-        "text-color": "rgba(102, 102, 102, 1)",
-        "text-halo-width": 1.2,
-        "text-halo-color": "rgba(255,255,255,0.8)"
-      }
-    },
-    {
-      "id": "place-city-rank3",
-      "type": "symbol",
-      "source": "geolonia",
-      "source-layer": "place",
-      "minzoom": 8,
-      "filter": [
-        "all",
-        [
-          "==",
-          "class",
-          "city"
-        ],
-        [
-          "==",
-          "rank",
-          3
-        ],
-        [
-          "!=",
-          "disputed",
-          "japan_northern_territories"
-        ]
-      ],
-      "layout": {
-        "text-font": [
-          "Noto Sans Regular"
-        ],
-        "text-size": 14,
-        "text-field": "{name}",
-        "text-max-width": 8,
-        "visibility": "visible"
-      },
-      "paint": {
-        "text-color": "rgba(102, 102, 102, 1)",
-        "text-halo-width": 1.2,
-        "text-halo-color": "rgba(255,255,255,0.8)"
-      }
-    },
-    {
-      "id": "place-city-rank2",
-      "type": "symbol",
-      "source": "geolonia",
-      "source-layer": "place",
-      "minzoom": 8,
-      "filter": [
-        "all",
-        [
-          "==",
-          "class",
-          "city"
-        ],
-        [
-          "==",
-          "rank",
+          "capital",
           2
+        ],
+        [
+          "==",
+          "class",
+          "city"
         ],
         [
           "!=",

--- a/style.json
+++ b/style.json
@@ -5035,7 +5035,7 @@
       "type": "symbol",
       "source": "geolonia",
       "source-layer": "place",
-      "minzoom": 8,
+      "minzoom": 8.5,
       "filter": [
         "all",
         [
@@ -5126,7 +5126,7 @@
       "type": "symbol",
       "source": "geolonia",
       "source-layer": "place",
-      "minzoom": 10,
+      "minzoom": 8,
       "filter": [
         "all",
         [
@@ -5149,7 +5149,21 @@
           "disputed",
           "japan_northern_territories"
         ]
-      ]
+      ],
+      "layout": {
+        "text-font": [
+          "Noto Sans Regular"
+        ],
+        "text-size": 14,
+        "text-field": "{name}",
+        "text-max-width": 8,
+        "visibility": "visible"
+      },
+      "paint": {
+        "text-color": "rgba(102, 102, 102, 1)",
+        "text-halo-width": 1.2,
+        "text-halo-color": "rgba(255,255,255,0.8)"
+      }
     },
     {
       "id": "place-city-rank5",

--- a/style.json
+++ b/style.json
@@ -4402,12 +4402,12 @@
     {
       "id": "building-3d",
       "type": "fill-extrusion",
-      "source": "geolonia",
-      "source-layer": "building",
-      "minzoom": 15,
       "metadata": {
         "visible-on-3d": true
       },
+      "source": "geolonia",
+      "source-layer": "building",
+      "minzoom": 15,
       "layout": {
         "visibility": "none"
       },
@@ -4985,84 +4985,6 @@
       }
     },
     {
-      "id": "place-village",
-      "type": "symbol",
-      "source": "geolonia",
-      "source-layer": "place",
-      "filter": [
-        "all",
-        [
-          "==",
-          "class",
-          "village"
-        ],
-        [
-          "!=",
-          "disputed",
-          "japan_northern_territories"
-        ]
-      ],
-      "layout": {
-        "text-font": [
-          "Noto Sans Regular"
-        ],
-        "text-size": {
-          "base": 1.2,
-          "stops": [
-            [
-              10,
-              12
-            ],
-            [
-              15,
-              22
-            ]
-          ]
-        },
-        "text-field": "{name}",
-        "text-max-width": 8,
-        "visibility": "visible"
-      },
-      "paint": {
-        "text-color": "#333",
-        "text-halo-width": 1.2,
-        "text-halo-color": "rgba(255,255,255,0.8)"
-      }
-    },
-    {
-      "id": "place-town",
-      "type": "symbol",
-      "source": "geolonia",
-      "source-layer": "place",
-      "filter": [
-        "all",
-        [
-          "==",
-          "class",
-          "town"
-        ],
-        [
-          "!=",
-          "disputed",
-          "japan_northern_territories"
-        ]
-      ],
-      "layout": {
-        "text-font": [
-          "Noto Sans Regular"
-        ],
-        "text-size": 14,
-        "text-field": "{name}",
-        "text-max-width": 8,
-        "visibility": "visible"
-      },
-      "paint": {
-        "text-color": "rgba(102, 102, 102, 1)",
-        "text-halo-width": 1.2,
-        "text-halo-color": "rgba(255,255,255,0.8)"
-      }
-    },
-    {
       "id": "place-island-name",
       "type": "symbol",
       "source": "geolonia",
@@ -5120,7 +5042,71 @@
       }
     },
     {
-      "id": "place-city",
+      "id": "place-city-rank6-later",
+      "type": "symbol",
+      "source": "geolonia",
+      "source-layer": "place",
+      "minzoom": 9,
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "city"
+        ],
+        [
+          "==",
+          "rank",
+          5
+        ],
+        [
+          "!=",
+          "disputed",
+          "japan_northern_territories"
+        ]
+      ]
+    },
+    {
+      "id": "place-city-rank5",
+      "type": "symbol",
+      "source": "geolonia",
+      "source-layer": "place",
+      "minzoom": 9,
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "city"
+        ],
+        [
+          "==",
+          "rank",
+          5
+        ],
+        [
+          "!=",
+          "disputed",
+          "japan_northern_territories"
+        ]
+      ],
+      "layout": {
+        "text-font": [
+          "Noto Sans Regular"
+        ],
+        "text-size": 14,
+        "text-field": "{name}",
+        "text-max-width": 8,
+        "visibility": "visible"
+      },
+      "paint": {
+        "text-color": "rgba(102, 102, 102, 1)",
+        "text-halo-width": 1.2,
+        "text-halo-color": "rgba(255,255,255,0.8)"
+      }
+    },
+    {
+      "id": "place-city-rank4",
       "type": "symbol",
       "source": "geolonia",
       "source-layer": "place",
@@ -5128,14 +5114,92 @@
       "filter": [
         "all",
         [
-          "!=",
-          "capital",
-          2
+          "==",
+          "class",
+          "city"
         ],
+        [
+          "==",
+          "rank",
+          4
+        ],
+        [
+          "!=",
+          "disputed",
+          "japan_northern_territories"
+        ]
+      ],
+      "layout": {
+        "text-font": [
+          "Noto Sans Regular"
+        ],
+        "text-size": 14,
+        "text-field": "{name}",
+        "text-max-width": 8,
+        "visibility": "visible"
+      },
+      "paint": {
+        "text-color": "rgba(102, 102, 102, 1)",
+        "text-halo-width": 1.2,
+        "text-halo-color": "rgba(255,255,255,0.8)"
+      }
+    },
+    {
+      "id": "place-city-rank3",
+      "type": "symbol",
+      "source": "geolonia",
+      "source-layer": "place",
+      "minzoom": 8,
+      "filter": [
+        "all",
         [
           "==",
           "class",
           "city"
+        ],
+        [
+          "==",
+          "rank",
+          3
+        ],
+        [
+          "!=",
+          "disputed",
+          "japan_northern_territories"
+        ]
+      ],
+      "layout": {
+        "text-font": [
+          "Noto Sans Regular"
+        ],
+        "text-size": 14,
+        "text-field": "{name}",
+        "text-max-width": 8,
+        "visibility": "visible"
+      },
+      "paint": {
+        "text-color": "rgba(102, 102, 102, 1)",
+        "text-halo-width": 1.2,
+        "text-halo-color": "rgba(255,255,255,0.8)"
+      }
+    },
+    {
+      "id": "place-city-rank2",
+      "type": "symbol",
+      "source": "geolonia",
+      "source-layer": "place",
+      "minzoom": 8,
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "city"
+        ],
+        [
+          "==",
+          "rank",
+          2
         ],
         [
           "!=",

--- a/style.json
+++ b/style.json
@@ -5130,6 +5130,11 @@
       "filter": [
         "all",
         [
+          "!=",
+          "capital",
+          2
+        ],
+        [
           "==",
           "class",
           "city"
@@ -5154,6 +5159,11 @@
       "minzoom": 10,
       "filter": [
         "all",
+        [
+          "!=",
+          "capital",
+          2
+        ],
         [
           "==",
           "class",
@@ -5194,6 +5204,11 @@
       "filter": [
         "all",
         [
+          "!=",
+          "capital",
+          2
+        ],
+        [
           "==",
           "class",
           "city"
@@ -5233,6 +5248,11 @@
       "filter": [
         "all",
         [
+          "!=",
+          "capital",
+          2
+        ],
+        [
           "==",
           "class",
           "city"
@@ -5271,6 +5291,11 @@
       "minzoom": 8,
       "filter": [
         "all",
+        [
+          "!=",
+          "capital",
+          2
+        ],
         [
           "==",
           "class",

--- a/style.json
+++ b/style.json
@@ -4402,12 +4402,12 @@
     {
       "id": "building-3d",
       "type": "fill-extrusion",
-      "metadata": {
-        "visible-on-3d": true
-      },
       "source": "geolonia",
       "source-layer": "building",
       "minzoom": 15,
+      "metadata": {
+        "visible-on-3d": true
+      },
       "layout": {
         "visibility": "none"
       },

--- a/style.json
+++ b/style.json
@@ -14,7 +14,7 @@
     "geolonia": {
       "type": "vector",
       "minzoom": 8,
-      "url": "https://tileserver.geolonia.com/v2/tiles.json?key=YOUR-API-KEY"
+      "url": "https://tileserver.geolonia.com/gtv3-5b162427-5b85-4fc5-86de-6b5183050b2c/tiles.json?key=YOUR-API-KEY"
     }
   },
   "sprite": "https://sprites.geolonia.com/basic",

--- a/style.json
+++ b/style.json
@@ -5329,7 +5329,7 @@
         "text-font": [
           "Noto Sans Regular"
         ],
-        "text-size": 14,
+        "text-size": 18,
         "text-field": "{name}",
         "text-max-width": 8,
         "icon-image": "star-11",

--- a/style.json
+++ b/style.json
@@ -5122,7 +5122,7 @@
       }
     },
     {
-      "id": "place-city-rank6-more",
+      "id": "place-city-rank10",
       "type": "symbol",
       "source": "geolonia",
       "source-layer": "place",
@@ -5140,7 +5140,183 @@
           "city"
         ],
         [
-          ">=",
+          "==",
+          "rank",
+          10
+        ],
+        [
+          "!=",
+          "disputed",
+          "japan_northern_territories"
+        ]
+      ],
+      "layout": {
+        "text-font": [
+          "Noto Sans Regular"
+        ],
+        "text-size": 14,
+        "text-field": "{name}",
+        "text-max-width": 8,
+        "visibility": "visible"
+      },
+      "paint": {
+        "text-color": "rgba(102, 102, 102, 1)",
+        "text-halo-width": 1.2,
+        "text-halo-color": "rgba(255,255,255,0.8)"
+      }
+    },
+    {
+      "id": "place-city-rank9",
+      "type": "symbol",
+      "source": "geolonia",
+      "source-layer": "place",
+      "minzoom": 8,
+      "filter": [
+        "all",
+        [
+          "!=",
+          "capital",
+          2
+        ],
+        [
+          "==",
+          "class",
+          "city"
+        ],
+        [
+          "==",
+          "rank",
+          9
+        ],
+        [
+          "!=",
+          "disputed",
+          "japan_northern_territories"
+        ]
+      ],
+      "layout": {
+        "text-font": [
+          "Noto Sans Regular"
+        ],
+        "text-size": 14,
+        "text-field": "{name}",
+        "text-max-width": 8,
+        "visibility": "visible"
+      },
+      "paint": {
+        "text-color": "rgba(102, 102, 102, 1)",
+        "text-halo-width": 1.2,
+        "text-halo-color": "rgba(255,255,255,0.8)"
+      }
+    },
+    {
+      "id": "place-city-rank8",
+      "type": "symbol",
+      "source": "geolonia",
+      "source-layer": "place",
+      "minzoom": 8,
+      "filter": [
+        "all",
+        [
+          "!=",
+          "capital",
+          2
+        ],
+        [
+          "==",
+          "class",
+          "city"
+        ],
+        [
+          "==",
+          "rank",
+          8
+        ],
+        [
+          "!=",
+          "disputed",
+          "japan_northern_territories"
+        ]
+      ],
+      "layout": {
+        "text-font": [
+          "Noto Sans Regular"
+        ],
+        "text-size": 14,
+        "text-field": "{name}",
+        "text-max-width": 8,
+        "visibility": "visible"
+      },
+      "paint": {
+        "text-color": "rgba(102, 102, 102, 1)",
+        "text-halo-width": 1.2,
+        "text-halo-color": "rgba(255,255,255,0.8)"
+      }
+    },
+    {
+      "id": "place-city-rank7",
+      "type": "symbol",
+      "source": "geolonia",
+      "source-layer": "place",
+      "minzoom": 8,
+      "filter": [
+        "all",
+        [
+          "!=",
+          "capital",
+          2
+        ],
+        [
+          "==",
+          "class",
+          "city"
+        ],
+        [
+          "==",
+          "rank",
+          7
+        ],
+        [
+          "!=",
+          "disputed",
+          "japan_northern_territories"
+        ]
+      ],
+      "layout": {
+        "text-font": [
+          "Noto Sans Regular"
+        ],
+        "text-size": 14,
+        "text-field": "{name}",
+        "text-max-width": 8,
+        "visibility": "visible"
+      },
+      "paint": {
+        "text-color": "rgba(102, 102, 102, 1)",
+        "text-halo-width": 1.2,
+        "text-halo-color": "rgba(255,255,255,0.8)"
+      }
+    },
+    {
+      "id": "place-city-rank6",
+      "type": "symbol",
+      "source": "geolonia",
+      "source-layer": "place",
+      "minzoom": 11,
+      "filter": [
+        "all",
+        [
+          "!=",
+          "capital",
+          2
+        ],
+        [
+          "==",
+          "class",
+          "city"
+        ],
+        [
+          "==",
           "rank",
           6
         ],

--- a/style.json
+++ b/style.json
@@ -5009,7 +5009,7 @@
         "text-anchor": "top",
         "text-offset": [
           0,
-          0.2
+          0.1
         ],
         "text-font": [
           "Noto Sans Regular"
@@ -5036,19 +5036,7 @@
         "icon-opacity": {
           "stops": [
             [
-              8,
-              1
-            ],
-            [
-              9,
-              1
-            ],
-            [
-              10,
-              1
-            ],
-            [
-              11,
+              11.9,
               1
             ],
             [
@@ -5087,7 +5075,7 @@
         "text-anchor": "top",
         "text-offset": [
           0,
-          0.2
+          0.1
         ],
         "text-font": [
           "Noto Sans Regular"
@@ -5102,19 +5090,7 @@
         "icon-opacity": {
           "stops": [
             [
-              8,
-              1
-            ],
-            [
-              9,
-              1
-            ],
-            [
-              10,
-              1
-            ],
-            [
-              11,
+              11.9,
               1
             ],
             [
@@ -5220,7 +5196,7 @@
         "text-anchor": "top",
         "text-offset": [
           0,
-          0.2
+          0.1
         ],
         "text-font": [
           "Noto Sans Regular"
@@ -5235,19 +5211,7 @@
         "icon-opacity": {
           "stops": [
             [
-              8,
-              1
-            ],
-            [
-              9,
-              1
-            ],
-            [
-              10,
-              1
-            ],
-            [
-              11,
+              11.9,
               1
             ],
             [
@@ -5296,7 +5260,7 @@
         "text-anchor": "top",
         "text-offset": [
           0,
-          0.2
+          0.1
         ],
         "text-font": [
           "Noto Sans Regular"
@@ -5311,19 +5275,7 @@
         "icon-opacity": {
           "stops": [
             [
-              8,
-              1
-            ],
-            [
-              9,
-              1
-            ],
-            [
-              10,
-              1
-            ],
-            [
-              11,
+              11.9,
               1
             ],
             [
@@ -5372,7 +5324,7 @@
         "text-anchor": "top",
         "text-offset": [
           0,
-          0.2
+          0.1
         ],
         "text-font": [
           "Noto Sans Regular"
@@ -5387,19 +5339,7 @@
         "icon-opacity": {
           "stops": [
             [
-              8,
-              1
-            ],
-            [
-              9,
-              1
-            ],
-            [
-              10,
-              1
-            ],
-            [
-              11,
+              11.9,
               1
             ],
             [
@@ -5448,7 +5388,7 @@
         "text-anchor": "top",
         "text-offset": [
           0,
-          0.2
+          0.1
         ],
         "text-font": [
           "Noto Sans Regular"
@@ -5463,19 +5403,7 @@
         "icon-opacity": {
           "stops": [
             [
-              8,
-              1
-            ],
-            [
-              9,
-              1
-            ],
-            [
-              10,
-              1
-            ],
-            [
-              11,
+              11.9,
               1
             ],
             [
@@ -5524,7 +5452,7 @@
         "text-anchor": "top",
         "text-offset": [
           0,
-          0.2
+          0.1
         ],
         "text-font": [
           "Noto Sans Regular"
@@ -5539,19 +5467,7 @@
         "icon-opacity": {
           "stops": [
             [
-              8,
-              1
-            ],
-            [
-              9,
-              1
-            ],
-            [
-              10,
-              1
-            ],
-            [
-              11,
+              11.9,
               1
             ],
             [
@@ -5600,7 +5516,7 @@
         "text-anchor": "top",
         "text-offset": [
           0,
-          0.2
+          0.1
         ],
         "text-font": [
           "Noto Sans Regular"
@@ -5615,19 +5531,7 @@
         "icon-opacity": {
           "stops": [
             [
-              8,
-              1
-            ],
-            [
-              9,
-              1
-            ],
-            [
-              10,
-              1
-            ],
-            [
-              11,
+              11.9,
               1
             ],
             [
@@ -5676,7 +5580,7 @@
         "text-anchor": "top",
         "text-offset": [
           0,
-          0.2
+          0.1
         ],
         "text-font": [
           "Noto Sans Regular"
@@ -5691,19 +5595,7 @@
         "icon-opacity": {
           "stops": [
             [
-              8,
-              1
-            ],
-            [
-              9,
-              1
-            ],
-            [
-              10,
-              1
-            ],
-            [
-              11,
+              11.9,
               1
             ],
             [
@@ -5752,7 +5644,7 @@
         "text-anchor": "top",
         "text-offset": [
           0,
-          0.2
+          0.1
         ],
         "text-font": [
           "Noto Sans Regular"
@@ -5767,19 +5659,7 @@
         "icon-opacity": {
           "stops": [
             [
-              8,
-              1
-            ],
-            [
-              9,
-              1
-            ],
-            [
-              10,
-              1
-            ],
-            [
-              11,
+              11.9,
               1
             ],
             [
@@ -5828,7 +5708,7 @@
         "text-anchor": "top",
         "text-offset": [
           0,
-          0.2
+          0.1
         ],
         "text-font": [
           "Noto Sans Regular"
@@ -5843,19 +5723,7 @@
         "icon-opacity": {
           "stops": [
             [
-              8,
-              1
-            ],
-            [
-              9,
-              1
-            ],
-            [
-              10,
-              1
-            ],
-            [
-              11,
+              11.9,
               1
             ],
             [

--- a/style.json
+++ b/style.json
@@ -14,7 +14,7 @@
     "geolonia": {
       "type": "vector",
       "minzoom": 8,
-      "url": "https://tileserver.geolonia.com/gtv3-5b162427-5b85-4fc5-86de-6b5183050b2c/tiles.json?key=YOUR-API-KEY"
+      "url": "https://tileserver.geolonia.com/v2/tiles.json?key=YOUR-API-KEY"
     }
   },
   "sprite": "https://sprites.geolonia.com/basic",


### PR DESCRIPTION
Close #45 

Z8で一気に市区町村名が表示されていたので、人口別にズームレベルとテキストサイズを調整しました。

`place-town `と `place-city-rank 2~ 3`が同じズームレベルなのは、地方だと `place-town` しかない状態で地図がスカスカになるので低ズームで表示しています。


Before
<img width="933" alt="スクリーンショット 2021-09-08 9 57 16" src="https://user-images.githubusercontent.com/8760841/132428655-69f30997-eaaf-4cbf-8712-36559dab42ef.png">

After
<img width="870" alt="スクリーンショット 2021-09-08 9 57 39" src="https://user-images.githubusercontent.com/8760841/132428662-015c4e55-9f67-4f5b-b4b1-b6538e1b0eb6.png">

画像はz8.35の時の表示。
