### PR TITLE
Oceanus の text-field の設定方法をシンプルなものに修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/layers/nt-water-name-ocean.yml
+++ b/layers/nt-water-name-ocean.yml
@@ -12,10 +12,7 @@ layout:
   text-font:
     - Noto Sans Regular
   text-size: 14
-  text-field:
-    - to-string
-    - - get
-      - name
+  text-field: '{name}'
   text-max-width: 5
   text-rotation-alignment: map
   symbol-placement: point

--- a/layers/nt-water-name-river.yml
+++ b/layers/nt-water-name-river.yml
@@ -12,10 +12,7 @@ layout:
   text-font:
     - Noto Sans Regular
   text-size: 14
-  text-field:
-    - to-string
-    - - get
-      - name
+  text-field: '{name}'
   text-max-width: 5
   text-rotation-alignment: map
   symbol-placement: point

--- a/layers/oc-airport.yml
+++ b/layers/oc-airport.yml
@@ -19,10 +19,7 @@ layout:
     - Noto Sans Regular
   text-anchor: top
   icon-image: airport
-  text-field:
-    - to-string
-    - - get
-      - name
+  text-field: '{name}'
   text-offset:
     - 0
     - 0.6

--- a/layers/oc-label-country.yml
+++ b/layers/oc-label-country.yml
@@ -12,10 +12,7 @@ layout:
   text-font:
     - Noto Sans Regular
   text-size: 14
-  text-field:
-    - to-string
-    - - get
-      - name
+  text-field: '{name}'
   text-max-width: 8
   visibility: visible
 paint:

--- a/layers/oc-label-pref-capital-ja.yml
+++ b/layers/oc-label-pref-capital-ja.yml
@@ -22,10 +22,7 @@ layout:
     - right
   icon-image: circle
   icon-allow-overlap: true
-  text-field:
-    - to-string
-    - - get
-      - name
+  text-field: '{name}'
   text-offset:
     - 0.6
     - 0.6

--- a/layers/oc-label-pref-ja.yml
+++ b/layers/oc-label-pref-ja.yml
@@ -16,10 +16,7 @@ layout:
   text-font:
     - Noto Sans Regular
   text-size: 14
-  text-field:
-    - to-string
-    - - get
-      - name
+  text-field: '{name}'
   text-max-width: 8
   visibility: visible
 paint:

--- a/layers/oc-label-pref.yml
+++ b/layers/oc-label-pref.yml
@@ -17,10 +17,7 @@ layout:
   text-font:
     - Noto Sans Regular
   text-size: 14
-  text-field:
-    - to-string
-    - - get
-      - name
+  text-field: '{name}'
   text-max-width: 8
   visibility: visible
 paint:

--- a/layers/oc-label-town-ja.yml
+++ b/layers/oc-label-town-ja.yml
@@ -22,10 +22,7 @@ layout:
     - Noto Sans Regular
   text-anchor: top
   icon-image: circle
-  text-field:
-    - to-string
-    - - get
-      - name
+  text-field: '{name}'
   text-offset:
     - 0
     - 0.6

--- a/layers/oc-label-town.yml
+++ b/layers/oc-label-town.yml
@@ -19,10 +19,7 @@ layout:
     - Noto Sans Regular
   text-anchor: top
   icon-image: circle
-  text-field:
-    - to-string
-    - - get
-      - name
+  text-field: '{name}'
   text-offset:
     - 0
     - 0.6

--- a/layers/oc-water-name-ocean.yml
+++ b/layers/oc-water-name-ocean.yml
@@ -15,10 +15,7 @@ layout:
   text-font:
     - Noto Sans Regular
   text-size: 14
-  text-field:
-    - to-string
-    - - get
-      - name
+  text-field: '{name}'
   text-max-width: 5
   text-rotation-alignment: map
   symbol-placement: point

--- a/layers/oc-water-name-other.yml
+++ b/layers/oc-water-name-other.yml
@@ -21,10 +21,7 @@ layout:
     - 10
     - 6
     - 14
-  text-field:
-    - to-string
-    - - get
-      - name
+  text-field: '{name}'
   text-max-width: 5
   text-rotation-alignment: map
   symbol-placement: point


### PR DESCRIPTION
以下との整合性を保ち、コードをシンプルに保つのが目的です。
https://github.com/geolonia/gsi/pull/24
https://github.com/geolonia/basic/pull/65