### PR TITLE
進行方向矢印のサイズ・間隔調整

### DIFF
--- a/layers/road_oneway.yml
+++ b/layers/road_oneway.yml
@@ -23,15 +23,15 @@ filter:
 layout:
   symbol-placement: line
   icon-image: oneway
-  symbol-spacing: 150
+  symbol-spacing: 250
   icon-padding: 2
   icon-rotation-alignment: map
   icon-rotate: 90
   icon-size:
     stops:
       - - 15
-        - 0.5
+        - 0.4
       - - 19
-        - 0.6
+        - 0.8
 paint:
-  icon-opacity: 0.3
+  icon-opacity: 0.4

--- a/layers/road_oneway.yml
+++ b/layers/road_oneway.yml
@@ -2,7 +2,7 @@ id: road_oneway
 type: symbol
 source: geolonia
 source-layer: transportation
-minzoom: 15
+minzoom: 16
 filter:
   - all
   - - '=='

--- a/layers/road_oneway.yml
+++ b/layers/road_oneway.yml
@@ -23,7 +23,7 @@ filter:
 layout:
   symbol-placement: line
   icon-image: oneway
-  symbol-spacing: 75
+  symbol-spacing: 150
   icon-padding: 2
   icon-rotation-alignment: map
   icon-rotate: 90
@@ -32,6 +32,6 @@ layout:
       - - 15
         - 0.5
       - - 19
-        - 1
+        - 0.6
 paint:
-  icon-opacity: 0.5
+  icon-opacity: 0.3


### PR DESCRIPTION
Close #12 
進行方向矢印のサイズが目立ちすぎていたので
下記のように調整致しました。

・zoomレベル15では地図が細かく認識しづらく表示の必要がなさそうだったので、ミニマムを15→16に変更
・1ブロックに数本表示されていたので1本/1ブロック程度になるように間引き
・ランドマークとなる建物や文字表示よりも目立たないようにカラー・サイズ調整

## before
https://geoloniamaps.github.io/basic/#16/35.676431/139.77147
![FireShot Capture 175 - Geolonia Map - geoloniamaps github io](https://user-images.githubusercontent.com/3376589/145747194-12082828-8514-4543-8f5b-2cbc59804db7.png)


## after
https://geoloniamaps.github.io/basic/change-oneway-arrow-size/#16/35.676431/139.77147
![FireShot Capture 174 - Charites Live Preview - localhost](https://user-images.githubusercontent.com/3376589/145747156-250e97fa-3b09-4910-9e2c-05ba5b4d9dfe.png)
