### PR TITLE
use tileJson for gsi-dem

### DIFF
--- a/style.yml
+++ b/style.yml
@@ -20,7 +20,7 @@ sources:
   dem:
     type: raster-dem
     tiles:
-    - https://tileserver.geolonia.com/gsi-dem/tiles/{z}/{x}/{y}.png?key=YOUR-API-KEY
+    - https://tileserver.geolonia.com/gsi-dem/tiles.json?key=YOUR-API-KEY
     attribution: <a href="https://maps.gsi.go.jp/development/ichiran.html" target="_blank">© GSI Japan</a>
 sprite: https://geoloniamaps.github.io/basic/basic
 glyphs: https://glyphs.geolonia.com/{fontstack}/{range}.pbf

--- a/style.yml
+++ b/style.yml
@@ -19,8 +19,7 @@ sources:
     url: https://tileserver.geolonia.com/v2/tiles.json?key=YOUR-API-KEY
   dem:
     type: raster-dem
-    tiles:
-    - https://tileserver.geolonia.com/gsi-dem/tiles.json?key=YOUR-API-KEY
+    url: https://tileserver.geolonia.com/gsi-dem/tiles.json?key=YOUR-API-KEY
     attribution: <a href="https://maps.gsi.go.jp/development/ichiran.html" target="_blank">© GSI Japan</a>
 sprite: https://geoloniamaps.github.io/basic/basic
 glyphs: https://glyphs.geolonia.com/{fontstack}/{range}.pbf


### PR DESCRIPTION
fix #97 
source の gsi-dem の URL 形式を、tiles.json を使用するように変更。
~~ただ dem が反映されなくなったので要確認。~~