### PR TITLE
move motorway-casing

### DIFF
--- a/style.yml
+++ b/style.yml
@@ -106,13 +106,13 @@ layers:
   - !!inc/file layers/bridge-link-casing.yml
   - !!inc/file layers/bridge-secondary-tertiary-casing.yml
   - !!inc/file layers/bridge-trunk-primary-casing.yml
-  - !!inc/file layers/bridge-motorway-casing.yml
   - !!inc/file layers/bridge-path-casing.yml
   - !!inc/file layers/bridge-path.yml
   - !!inc/file layers/bridge-motorway-link.yml
   - !!inc/file layers/bridge-link.yml
   - !!inc/file layers/bridge-secondary-tertiary.yml
   - !!inc/file layers/bridge-trunk-primary.yml
+  - !!inc/file layers/bridge-motorway-casing.yml
   - !!inc/file layers/bridge-motorway.yml
   - !!inc/file layers/railway.yml
   - !!inc/file layers/railway-hatching.yml


### PR DESCRIPTION
高速道路の橋（`bridge-motorway`）と 国道の橋（`bridge-trunk-primary`）が重なっている時に、繋がって見える問題を修正しました。

Before
https://geoloniamaps.github.io/basic/#20/34.6925499/135.4962064
![スクリーンショット 2022-02-10 15 48 13](https://user-images.githubusercontent.com/8760841/153352773-fe762e28-458c-49fd-96ad-a37c3c07eab4.png)


After
https://geoloniamaps.github.io/basic/fix-road-order/#20/34.6925397/135.4961769

![スクリーンショット 2022-02-10 15 55 33](https://user-images.githubusercontent.com/8760841/153353664-6e663857-e4cd-4c6e-9b9e-3a8268cbda0a.png)


国道・市区町村道・歩道の橋が、高速道路の橋の上を交差している場合、スタイルが崩れますが、歩道や市区町村道の橋が高速道路の橋の上を通っているケースは少ないと思っています。

あるとすれば、国道の橋かなと思ったのですが、国道が高速道路の上を通っているケースを探しても、下のようにトンネルになった高速道路の上を通っているケースしか見つからなかったので、スタイルの崩れはおそらくないと思います。

https://maps.geolonia.com/#style=geolonia/basic&map=19/35.6683128/139.7686562
