### PR TITLE
Set maxzoom 12 for hillshading style layer

### DIFF
--- a/layers/hillshading.yml
+++ b/layers/hillshading.yml
@@ -1,6 +1,7 @@
 id: hillshading
 source: dem
 type: hillshade
+maxzoom: 12
 paint:
   hillshade-exaggeration:
     stops:


### PR DESCRIPTION
Fix #103 

> 現状、z16-z18でもgsi-demのタイルがリクエストされていますが、hillshadeが見えなくなったズームまでmaxzoom設定できるかな？

hillshading レイヤーで、陰影タイルを ズーム12 以降は使っていなかったので `maxzoom: 12` を設定しました。