### PR TITLE
高ズームでは等深線情報は必要ないので非表示にする

### DIFF
--- a/layers/oc-ocean.yml
+++ b/layers/oc-ocean.yml
@@ -2,6 +2,7 @@ id: oc-ocean200
 type: fill
 source: oceanus
 source-layer: oc-water
+maxzoom: 10
 filter:
   - all
   - - '=='
@@ -10,7 +11,14 @@ filter:
     - ocean
 layout:
   visibility: visible
+
 paint:
+  fill-opacity:
+    stops:
+    - - 9
+      - 1
+    - - 10
+      - 0
   fill-color:
     - match
     - ['get', 'depth']


### PR DESCRIPTION
Fix #92 

現在、高ズームでも等深線が表示されていますが、高ズームでは等深線は必要ないので、zoom9 → zoom10にかけて非表示にするようにしました。

高ズームでより、必要な情報にフォーカスできるかと思います。

Before 
![スクリーンショット 2022-02-15 18 14 06](https://user-images.githubusercontent.com/8760841/154030301-c424ab72-bfd7-4329-9466-a760472e196a.png)

After
![スクリーンショット 2022-02-15 18 14 58](https://user-images.githubusercontent.com/8760841/154030784-7c86954b-2be0-4db2-94f3-2c33246ac507.png)

