### PR TITLE
一般県道・市区町村道のminzoom を 12 に設定

### DIFF
--- a/layers/building.yml
+++ b/layers/building.yml
@@ -4,6 +4,6 @@ source: geolonia
 source-layer: building
 minzoom: 16
 paint:
-  fill-color: '#D7D4D1'
+  fill-color: 'rgba(204, 204, 204, 0.5)'
   fill-outline-color: '#C6C3BF'
   fill-antialias: true

--- a/layers/highway-secondary-tertiary-casing.yml
+++ b/layers/highway-secondary-tertiary-casing.yml
@@ -18,7 +18,12 @@ layout:
   visibility: visible
 paint:
   line-color: rgba(222, 222, 222, 1)
-  line-opacity: 1
+  line-opacity:
+    stops:
+      - - 12
+        - 0
+      - - 13
+        - 1
   line-width:
     base: 1.2
     stops:

--- a/layers/highway-secondary-tertiary.yml
+++ b/layers/highway-secondary-tertiary.yml
@@ -18,6 +18,12 @@ layout:
   visibility: visible
 paint:
   line-color: rgba(255, 255, 255, 1)
+  line-opacity:
+    stops:
+      - - 12
+        - 0
+      - - 13
+        - 1
   line-width:
     base: 1.2
     stops:

--- a/layers/tunnel-secondary-tertiary-casing.yml
+++ b/layers/tunnel-secondary-tertiary-casing.yml
@@ -15,7 +15,12 @@ layout:
   line-join: round
 paint:
   line-color: '#e9ac77'
-  line-opacity: 1
+  line-opacity:
+    stops:
+      - - 12
+        - 0
+      - - 13
+        - 1
   line-width:
     base: 1.2
     stops:

--- a/layers/tunnel-secondary-tertiary.yml
+++ b/layers/tunnel-secondary-tertiary.yml
@@ -15,6 +15,12 @@ layout:
   line-join: round
 paint:
   line-color: '#fff4c6'
+  line-opacity:
+    stops:
+      - - 12
+        - 0
+      - - 13
+        - 1
   line-width:
     base: 1.2
     stops:


### PR DESCRIPTION
Fix #84 

一般県道・市区町村道の通常部とトンネルを、zoom12から表示するようにしました。（橋を含めなかったのは、低ズームで橋がないと道が分断されたように見える箇所があったからです。）


## 修正前・後比較

左がAfter 、右がBeforeです。
![スクリーンショット 2022-02-16 17 49 43](https://user-images.githubusercontent.com/8760841/154228655-3bb1c71b-e210-44c0-bc5f-4ad4c02e5483.png)

After
https://geoloniamaps.github.io/basic/change-minzoom-prefecture-cities-road/#12/35.67986/139.76484

Before
https://geoloniamaps.github.io/basic/change-background-color-highzoom/#12/35.67986/139.76484