### PR TITLE
国名と県名のラベルの色とフォントを読みやすいように変更

### DIFF
--- a/.github/workflows/index.html
+++ b/.github/workflows/index.html
@@ -7,7 +7,8 @@
   <title>Deploy Preview - Geolonia Map</title>
   <style>
     html,
-    body {
+    body,
+    .left {
       width: 100%;
       height: 100%;
       margin: 0;
@@ -15,21 +16,24 @@
       background-color: #555555;
     }
 
-    .left {
-      margin-right: 400px;
-      height: 100%;
-      background-color: #FFFFFF;
-    }
+    @media screen and (min-width: 1024px) {
+      .left {
+        width: auto;
+        margin-right: 400px;
+        height: 100%;
+        background-color: #FFFFFF;
+      }
 
-    .right {
-      margin-left: calc(100% - 400px);
-      position: absolute;
-      top: 0;
-      padding: 8px 16px;
-      height: calc(100% - 48px);
-      width: calc(400px - 32px);
-      overflow: scroll;
-      color: #FFFFFF;
+      .right {
+        margin-left: calc(100% - 400px);
+        position: absolute;
+        top: 0;
+        padding: 8px 16px;
+        height: calc(100% - 48px);
+        width: calc(400px - 32px);
+        overflow: scroll;
+        color: #FFFFFF;
+      }
     }
   </style>
 </head>

--- a/layers/oc-label-country.yml
+++ b/layers/oc-label-country.yml
@@ -10,12 +10,17 @@ filter:
   - country
 layout:
   text-font:
-    - Noto Sans Regular
-  text-size: 14
+    - Noto Sans Bold
+  text-size:
+    stops:
+      - - 0
+        - 9
+      - - 8
+        - 16
   text-field: '{name}'
   text-max-width: 8
   visibility: visible
 paint:
-  text-color: rgba(102, 102, 102, 1)
+  text-color: rgba(71, 71, 71, 1)
   text-halo-width: 1.2
   text-halo-color: rgba(255,255,255,0.8)

--- a/layers/oc-label-pref-capital-ja.yml
+++ b/layers/oc-label-pref-capital-ja.yml
@@ -30,6 +30,6 @@ layout:
   text-max-width: 9
 paint:
   text-halo-blur: 0.5
-  text-color: '#666'
+  text-color: 'rgba(71, 71, 71, 1)'
   text-halo-width: 1
   text-halo-color: '#ffffff'

--- a/layers/oc-label-pref-ja.yml
+++ b/layers/oc-label-pref-ja.yml
@@ -14,8 +14,13 @@ filter:
     - jflag
 layout:
   text-font:
-    - Noto Sans Regular
-  text-size: 14
+    - Noto Sans Bold
+  text-size:
+    stops:
+      - - 5
+        - 12
+      - - 8
+        - 14
   text-field: '{name}'
   text-max-width: 8
   visibility: visible

--- a/layers/oc-label-pref.yml
+++ b/layers/oc-label-pref.yml
@@ -15,8 +15,13 @@ filter:
     - false
 layout:
   text-font:
-    - Noto Sans Regular
-  text-size: 14
+    - Noto Sans Bold
+  text-size:
+    stops:
+      - - 5
+        - 12
+      - - 8
+        - 14
   text-field: '{name}'
   text-max-width: 8
   visibility: visible


### PR DESCRIPTION
Fix #96 

モバイルで見た時に、国名と県名・県庁所在地のラベルが見にくかったので読みやすいように修正しました。色や、フォント、サイズなどでこっちの方が見やすいよ。などあれば提案いただけると助かります!


## 国名比較

| Before  |  After  |
| ---- | ---- |
|  <img src="https://user-images.githubusercontent.com/8760841/154415145-a0eb276c-30fe-43b6-8a8b-bee0f402e501.PNG" style="width: 50%;" />  |  <img src="https://user-images.githubusercontent.com/8760841/154415192-9020ea4b-b34b-4ed5-afed-b1536d35cde0.PNG" style="width: 50%;" />  |


## 都道府県・県庁所在地込み

| Before  |  After  |
| ---- | ---- |
|  ![IMG_0746D99D305A-1](https://user-images.githubusercontent.com/8760841/154415937-97a24c11-b3e5-4937-a00d-bcd541d76812.jpeg)  |  ![IMG_1279](https://user-images.githubusercontent.com/8760841/154415692-ef4e4ab3-4df9-49b7-a940-2d74de3eba9e.PNG)  |



