### PR TITLE
県境の色と太さを調整

### DIFF
--- a/layers/boundary-land-level-4.yml
+++ b/layers/boundary-land-level-4.yml
@@ -12,12 +12,7 @@ filter:
 layout:
   line-join: round
 paint:
-  line-color: 
-    stops:
-      - - 8
-        - 'rgba(85,85,85,0.7)'
-      - - 12
-        - 'rgba(85,85,85,0.7)'
+  line-color: 'rgba(68,68,68,0.7)'
   line-dasharray:
     - 3
     - 1

--- a/layers/boundary-land-level-4.yml
+++ b/layers/boundary-land-level-4.yml
@@ -12,18 +12,21 @@ filter:
 layout:
   line-join: round
 paint:
-  line-color: '#999'
+  line-color: 
+    stops:
+      - - 8
+        - 'rgba(85,85,85,0.7)'
+      - - 12
+        - 'rgba(85,85,85,0.7)'
   line-dasharray:
-    - 2
+    - 3
     - 1
     - 1
     - 1
   line-width:
     base: 1.4
     stops:
-      - - 4
-        - 0.4
-      - - 5
-        - 2
+      - - 8
+        - 1.2
       - - 12
-        - 3
+        - 2

--- a/layers/boundary-land-level-4.yml
+++ b/layers/boundary-land-level-4.yml
@@ -12,9 +12,9 @@ filter:
 layout:
   line-join: round
 paint:
-  line-color: '#9e9cab'
+  line-color: '#999'
   line-dasharray:
-    - 3
+    - 2
     - 1
     - 1
     - 1
@@ -24,6 +24,6 @@ paint:
       - - 4
         - 0.4
       - - 5
-        - 1
-      - - 12
         - 2
+      - - 12
+        - 3

--- a/layers/oc-boundary-land-level-1-ja.yml
+++ b/layers/oc-boundary-land-level-1-ja.yml
@@ -15,10 +15,20 @@ filter:
 layout:
   line-join: round
 paint:
-  line-color: '#9e9cab'
+  line-color:
+    stops:
+      - - 4
+        - 'rgba(102,102,102,0.7)'
+      - - 7
+        - 'rgba(136,136,136,0.7)'
   line-dasharray:
     - 3
     - 1
     - 1
     - 1
-  line-width: 1
+  line-width: 
+    stops:
+      - - 4
+        - 1
+      - - 7
+        - 1.8

--- a/layers/oc-boundary-land-level-1-ja.yml
+++ b/layers/oc-boundary-land-level-1-ja.yml
@@ -29,6 +29,6 @@ paint:
   line-width: 
     stops:
       - - 4
-        - 1
+        - 0.5
       - - 7
         - 1.8


### PR DESCRIPTION
close #119

県境がはっきりと分かるように色と太さを調整しました。

■before
![FireShot Capture 190 - Deploy Preview - Geolonia Map - geoloniamaps github ioのコピー](https://user-images.githubusercontent.com/3376589/155629607-b35f4e69-3154-4598-a134-c7a0593ca4b0.png)
https://geoloniamaps.github.io/basic/#8.8/35.3433/138.6959

■after
![FireShot Capture 191 - Deploy Preview - Geolonia Map_ - deploy-preview-127--geoloniamaps-basic netlify appのコピー](https://user-images.githubusercontent.com/3376589/155629576-3d4c5382-2f8b-4673-afad-0245c369adaf.png)
https://deploy-preview-127--geoloniamaps-basic.netlify.app/#8.8/35.3433/138.6959
