### PR TITLE
橋のエリアを追加

### DIFF
--- a/layers/bridge-area.yml
+++ b/layers/bridge-area.yml
@@ -1,0 +1,11 @@
+id: bridge-area
+type: fill
+source: geolonia
+source-layer: landcover
+filter:
+  - all
+  - - '=='
+    - class
+    - bridge
+paint:
+  fill-color: rgba(254, 254, 254, 1)

--- a/style.yml
+++ b/style.yml
@@ -84,6 +84,7 @@ layers:
   - !!inc/file layers/aeroway-area.yml
   - !!inc/file layers/aeroway-taxiway.yml
   - !!inc/file layers/aeroway-runway.yml
+  - !!inc/file layers/bridge-area.yml
   - !!inc/file layers/highway-area.yml
   - !!inc/file layers/highway-motorway-link-casing.yml
   - !!inc/file layers/highway-link-casing.yml
@@ -100,7 +101,6 @@ layers:
   - !!inc/file layers/highway-primary.yml
   - !!inc/file layers/highway-trunk.yml
   - !!inc/file layers/highway-motorway.yml
-  - !!inc/file layers/bridge-area.yml
   - !!inc/file layers/bridge-motorway-link-casing.yml
   - !!inc/file layers/bridge-link-casing.yml
   - !!inc/file layers/bridge-secondary-tertiary-casing.yml

--- a/style.yml
+++ b/style.yml
@@ -100,6 +100,7 @@ layers:
   - !!inc/file layers/highway-primary.yml
   - !!inc/file layers/highway-trunk.yml
   - !!inc/file layers/highway-motorway.yml
+  - !!inc/file layers/bridge-area.yml
   - !!inc/file layers/bridge-motorway-link-casing.yml
   - !!inc/file layers/bridge-link-casing.yml
   - !!inc/file layers/bridge-secondary-tertiary-casing.yml


### PR DESCRIPTION
橋のエリアを追加しました。（OSM のデータにばらつきがあるので、橋エリアが追加されている箇所とされていない箇所があります）

レイヤーの読み込み順、地上の道路より下にした理由は、橋のエリアが上だと地上の道路と重なった時に、道路が一部消えて見えるからです。

Before
<img width="1439" alt="スクリーンショット 2022-03-01 12 29 50" src="https://user-images.githubusercontent.com/8760841/156099539-3ed2e461-4edb-454f-9f0b-22f4f73e59b8.png">
https://maps.geolonia.com/#style=geolonia/basic&lang=ja&map=17.68/34.764516/135.373772


After
<img width="1440" alt="スクリーンショット 2022-03-01 12 27 04" src="https://user-images.githubusercontent.com/8760841/156099629-67bcf8e2-aa05-4dc4-a57a-0f39a47bb81b.png">

