### PR TITLE
黒丸アイコンを白丸アイコンに変更

### DIFF
--- a/layers/oc-label-country.yml
+++ b/layers/oc-label-country.yml
@@ -21,6 +21,6 @@ layout:
   text-max-width: 8
   visibility: visible
 paint:
-  text-color: rgba(71, 71, 71, 1)
+  text-color: rgba(68, 68, 68, 1)
   text-halo-width: 1.2
   text-halo-color: rgba(255,255,255,0.8)

--- a/layers/oc-label-pref-capital-ja.yml
+++ b/layers/oc-label-pref-capital-ja.yml
@@ -20,7 +20,8 @@ layout:
     - bottom
     - left
     - right
-  icon-image: circle
+  icon-image: circle-stroked
+  icon-size: 0.8
   icon-allow-overlap: true
   text-field: '{name}'
   text-offset:

--- a/layers/oc-label-pref-ja.yml
+++ b/layers/oc-label-pref-ja.yml
@@ -18,13 +18,13 @@ layout:
   text-size:
     stops:
       - - 5
-        - 12
+        - 10
       - - 8
-        - 14
+        - 17
   text-field: '{name}'
   text-max-width: 8
   visibility: visible
 paint:
-  text-color: rgba(102, 102, 102, 1)
+  text-color: rgba(68, 68, 68, 1)
   text-halo-width: 1.2
   text-halo-color: rgba(255,255,255,0.8)

--- a/layers/oc-label-town-ja.yml
+++ b/layers/oc-label-town-ja.yml
@@ -21,7 +21,8 @@ layout:
   text-font:
     - Noto Sans Regular
   text-anchor: top
-  icon-image: circle
+  icon-image: circle-stroked
+  icon-size: 0.8
   text-field: '{name}'
   text-offset:
     - 0

--- a/layers/oc-label-town-ja.yml
+++ b/layers/oc-label-town-ja.yml
@@ -31,6 +31,6 @@ layout:
   text-max-width: 9
 paint:
   text-halo-blur: 0.5
-  text-color: '#666'
+  text-color: '#333'
   text-halo-width: 1
   text-halo-color: '#ffffff'

--- a/layers/place-city-capital.yml
+++ b/layers/place-city-capital.yml
@@ -15,15 +15,15 @@ filter:
     - japan_northern_territories
 layout:
   text-font:
-    - Noto Sans Regular
+    - Noto Sans Bold
   text-size: 18
   text-field: '{name}'
   text-max-width: 8
   icon-image: star
   text-offset:
     - 0.4
-    - 0
-  icon-size: 0.8
+    - -0.1
+  icon-size: 1
   text-anchor: left
   visibility: visible
 paint:

--- a/layers/place-city-rank2.yml
+++ b/layers/place-city-rank2.yml
@@ -23,10 +23,10 @@ layout:
   text-anchor: top
   text-offset:
     - 0
-    - 0.1
+    - 0.2
   text-font:
-    - Noto Sans Regular
-  text-size: 18
+    - Noto Sans bold
+  text-size: 17
   text-field: '{name}'
   text-max-width: 8
   visibility: visible
@@ -38,6 +38,6 @@ paint:
         - 1
       - - 12
         - 0
-  text-color: rgba(102, 102, 102, 1)
+  text-color: rgba(68, 68, 68, 1)
   text-halo-width: 1.2
   text-halo-color: rgba(255,255,255,0.8)

--- a/layers/place-city-rank2.yml
+++ b/layers/place-city-rank2.yml
@@ -18,8 +18,8 @@ filter:
     - disputed
     - japan_northern_territories
 layout:
-  icon-image: circle
-  icon-size: 0.5
+  icon-image: circle-stroked
+  icon-size: 0.8
   text-anchor: top
   text-offset:
     - 0


### PR DESCRIPTION
OC表示の際、県・地名のicon-circleをicon-strokeに変更し、
アイコンサイズや地名テキストのバランス調整を行いました。

■サンプル1
https://deploy-preview-145--geoloniamaps-basic.netlify.app/#6.96/36.246/138.079
![Frame 1](https://user-images.githubusercontent.com/3376589/156935727-07a89521-6d98-41f5-98bc-bf08344767a3.png)

■サンプル2
https://deploy-preview-145--geoloniamaps-basic.netlify.app/#7.96/35.742/139.215
![Frame 2](https://user-images.githubusercontent.com/3376589/156935744-0fad12b4-2538-452d-8bfc-79ea30bb5feb.png)

■サンプル3
zoom8以降も、rank2の都市を白丸に変更しました。
バランス調整のため、こちらもテキストのあしらい調整を行っております。
https://deploy-preview-145--geoloniamaps-basic.netlify.app/#8.96/35.6113/139.6739
![Frame 3](https://user-images.githubusercontent.com/3376589/156935750-551207ed-6c7e-4d44-ac23-24c4bf5b1dbe.png)
