### PR TITLE
鉄道の重なり順を変更

### DIFF
--- a/style.yml
+++ b/style.yml
@@ -116,6 +116,9 @@ layers:
   - !!inc/file layers/highway-primary.yml
   - !!inc/file layers/highway-trunk.yml
   - !!inc/file layers/highway-motorway.yml
+  - !!inc/file layers/railway.yml
+  - !!inc/file layers/railway-hatching.yml
+  - !!inc/file layers/railway-subway.yml
   - !!inc/file layers/bridge-motorway-link-casing.yml
   - !!inc/file layers/bridge-link-casing.yml
   - !!inc/file layers/bridge-secondary-tertiary-casing.yml
@@ -128,9 +131,6 @@ layers:
   - !!inc/file layers/bridge-trunk-primary.yml
   - !!inc/file layers/bridge-motorway-casing.yml
   - !!inc/file layers/bridge-motorway.yml
-  - !!inc/file layers/railway.yml
-  - !!inc/file layers/railway-hatching.yml
-  - !!inc/file layers/railway-subway.yml
   - !!inc/file layers/cablecar.yml
   - !!inc/file layers/cablecar-dash.yml
   - !!inc/file layers/boundary-land-level-4.yml


### PR DESCRIPTION
鉄道が高速道路の橋の上に表示されていたので修正。

![スクリーンショット 2022-07-09 11 29 34](https://user-images.githubusercontent.com/8760841/178088655-4d7b1172-ffc3-41e1-983e-ed8097bc8ca9.png)
