### PR TITLE
Update fude polygon attribution

### DIFF
--- a/docs/style.json
+++ b/docs/style.json
@@ -14,7 +14,6 @@
     "fudepoli": {
       "type": "vector",
       "url": "https://tileserver.geolonia.com/fudepoli_v0/tiles.json?key=YOUR-API-KEY",
-      "attribution": "<a href=\"https://www.maff.go.jp/j/tokei/porigon/attach/pdf/hudeporidl-1.pdf\" target=\"_blank\">© 農林水産省</a>",
       "minzoom": 13
     }
   },
@@ -185,26 +184,36 @@
       "type": "line",
       "source": "geolonia",
       "source-layer": "water",
-      "minzoom": 8,
+      "minzoom": 17,
       "layout": {
         "line-join": "round",
-        "line-round-limit": 0.5,
         "visibility": "visible"
       },
       "paint": {
         "line-color": "#62cffc",
-        "line-width": 10,
+        "line-width": {
+          "stops": [
+            [
+              17,
+              3
+            ],
+            [
+              20,
+              5
+            ]
+          ]
+        },
         "line-translate": {
           "stops": [
             [
-              14,
+              17,
               [
-                0,
-                0
+                1,
+                1
               ]
             ],
             [
-              17,
+              20,
               [
                 -2,
                 -2
@@ -212,19 +221,7 @@
             ]
           ]
         },
-        "line-opacity": {
-          "stops": [
-            [
-              14,
-              0.5
-            ],
-            [
-              17,
-              0.8
-            ]
-          ]
-        },
-        "line-blur": 10
+        "line-blur": 2
       }
     },
     {
@@ -232,7 +229,7 @@
       "type": "line",
       "source": "geolonia",
       "source-layer": "water",
-      "minzoom": 8,
+      "minzoom": 17,
       "filter": [
         "all",
         [
@@ -251,38 +248,37 @@
       },
       "paint": {
         "line-color": "#62cffc",
-        "line-width": 10,
+        "line-width": {
+          "stops": [
+            [
+              17,
+              3
+            ],
+            [
+              20,
+              5
+            ]
+          ]
+        },
         "line-translate": {
           "stops": [
             [
-              14,
+              17,
               [
-                0,
-                0
+                1,
+                1
               ]
             ],
             [
-              17,
+              20,
               [
-                0,
+                -2,
                 -2
               ]
             ]
           ]
         },
-        "line-opacity": {
-          "stops": [
-            [
-              14,
-              0
-            ],
-            [
-              17,
-              0.8
-            ]
-          ]
-        },
-        "line-blur": 10
+        "line-blur": 2
       }
     },
     {
@@ -639,7 +635,7 @@
       "type": "line",
       "source": "geolonia",
       "source-layer": "oc-water",
-      "minzoom": 4,
+      "minzoom": 17,
       "filter": [
         "all",
         [
@@ -666,38 +662,37 @@
       },
       "paint": {
         "line-color": "#62cffc",
-        "line-width": 5,
+        "line-width": {
+          "stops": [
+            [
+              17,
+              3
+            ],
+            [
+              20,
+              5
+            ]
+          ]
+        },
         "line-translate": {
           "stops": [
             [
-              14,
+              17,
               [
-                0,
-                0
+                1,
+                1
               ]
             ],
             [
-              17,
+              20,
               [
-                0,
+                -2,
                 -2
               ]
             ]
           ]
         },
-        "line-opacity": {
-          "stops": [
-            [
-              14,
-              0
-            ],
-            [
-              17,
-              0.8
-            ]
-          ]
-        },
-        "line-blur": 10
+        "line-blur": 2
       }
     },
     {

--- a/style.yml
+++ b/style.yml
@@ -15,7 +15,7 @@ sources:
   fudepoli:
     type: vector
     url: https://tileserver.geolonia.com/fudepoli_v0/tiles.json?key=YOUR-API-KEY
-    attribution: <a href="https://www.maff.go.jp/j/tokei/porigon/attach/pdf/hudeporidl-1.pdf" target="_blank">© 農林水産省</a>
+    attribution: <a href="https://www.maff.go.jp/j/tokei/porigon/index.html" target="_blank">「筆ポリゴンデータ」（農林水産省）を加工して作成</a>
     minzoom: 13
 sprite: https://geoloniamaps.github.io/basic/basic
 glyphs: https://glyphs.geolonia.com/{fontstack}/{range}.pbf

--- a/style.yml
+++ b/style.yml
@@ -15,7 +15,6 @@ sources:
   fudepoli:
     type: vector
     url: https://tileserver.geolonia.com/fudepoli_v0/tiles.json?key=YOUR-API-KEY
-    attribution: <a href="https://www.maff.go.jp/j/tokei/porigon/index.html" target="_blank">「筆ポリゴンデータ」（農林水産省）を加工して作成</a>
     minzoom: 13
 sprite: https://geoloniamaps.github.io/basic/basic
 glyphs: https://glyphs.geolonia.com/{fontstack}/{range}.pbf


### PR DESCRIPTION
筆ポリゴンのアトリビューションを、著作権情報ページに追加したので、スタイルから削除。
Related to https://github.com/geolonia/geolonia.com/pull/280
